### PR TITLE
Fix missing dependency

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,3 +16,5 @@ services:
     ports:
       - '3000:3000'
     command: [ 'sh', '-c', 'cd app && npx lite-server' ]
+    depends_on:
+      - api


### PR DESCRIPTION
Ah, this was the issue! Services need to be linked to be on the same network, `depends_on` does that automatically.